### PR TITLE
Fixed packed decimal unpacking on non-invariant culture machines.

### DIFF
--- a/Unplugged.IbmBits.Tests/IbmConverterTest.cs
+++ b/Unplugged.IbmBits.Tests/IbmConverterTest.cs
@@ -1,5 +1,6 @@
 ﻿#pragma warning disable IDE0230 // Use UTF-8 string literal
 using System.Collections;
+using System.Globalization;
 
 namespace Unplugged.IbmBits.Tests;
 
@@ -536,5 +537,16 @@ public class IbmConverterTest
         result.Should().Be(expected);
     }
 
-    #endregion
+    [Fact]
+    public void DecimalShouldBeTheSameInNonInvariantCulture()
+    {
+        Thread.CurrentThread.CurrentCulture = new CultureInfo("lt-LT");
+	    var expected = (decimal)123.45;
+	    var bytes = IbmConverter.GetBytes(expected);
+	    var result = IbmConverter.ToUnpackedDecimal(bytes, 2);
+
+	    result.Should().Be(expected);
+    }
+
+	#endregion
 }

--- a/Unplugged.IbmBits/IbmConverter.cs
+++ b/Unplugged.IbmBits/IbmConverter.cs
@@ -271,7 +271,7 @@ public static class IbmConverter
         if ((scale > 0 && strbuf.Length -scale>0))
             strbuf.Insert(strbuf.Length - scale, '.');
 
-        var result = decimal.Parse(strbuf.ToString());
+        var result = decimal.Parse(strbuf.ToString(), CultureInfo.InvariantCulture);
 
         tempData = inputData[inputLength - 1];
         tempData1 = tempData & 0x0F;


### PR DESCRIPTION
* Using InvarianCulture when parsing a decimal from a string build with a period as a decimal point.
* Added a test that uses non-invariant culture in the thread. Double checked, if that changes the thread culture for other tests - it looks like the change is only local to my new test.

Solves issue  #3